### PR TITLE
thermanager: fix typos, adjust for device specific sysfs

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -33,22 +33,26 @@
 		<resource name="temp-emmc" type="msm-adc">/sys/devices/00-vadc-3100/die_temp</resource>
 		<resource name="temp-batt" type="msm-adc">/sys/devices/00-vadc-3100/batt_therm</resource>
 		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
-		<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>
+		<!--<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>-->
 		<resource name="usb" type="sysfs">/sys/class/power_supply/usb/current_max</resource>
 		<resource name="charger" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
 		<resource name="charge_en" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
-		<resource name="temp-core" type="alias" resource="zone2" />
+
+		<resource name="temp-core" type="union">
+			<resource name="zone7" />
+			<resource name="zone8" />
+		</resource>
 
 		<resource name="temp-gpu" type="union">
-			<resource name="zone9" />
-			<resource name="zone10" />
+			<resource name="zone2" />
+			<resource name="zone3" />
 		</resource>
 
 		<resource name="temp-cpu" type="union">
+			<resource name="zone0" />
+			<resource name="zone1" />
+			<resource name="zone4" />
 			<resource name="zone5" />
-			<resource name="zone6" />
-			<resource name="zone7" />
-			<resource name="zone8" />
 		</resource>
 
 		<!-- TODO: -->
@@ -68,7 +72,7 @@
 		<mitigation level="6"><value resource="usb">150000</value></mitigation>
 	</control>
 
-	<control name="dc">
+	<!--<control name="dc">
 		<mitigation level="off"><value resource="dc">1800000</value></mitigation>
 		<mitigation level="1"><value resource="dc">1100000</value></mitigation>
 		<mitigation level="2"><value resource="dc">900000</value></mitigation>
@@ -76,7 +80,7 @@
 		<mitigation level="4"><value resource="dc">500000</value></mitigation>
 		<mitigation level="5"><value resource="dc">300000</value></mitigation>
 		<mitigation level="6"><value resource="dc">150000</value></mitigation>
-	</control>
+	</control>-->
 
 	<control name="charge_en">
 		<mitigation level="off"><value resource="charge_en">1</value></mitigation>
@@ -118,31 +122,28 @@
 		<mitigation level="1"><value resource="backlight">3083</value></mitigation>
 		<mitigation level="2"><value resource="backlight">2055</value></mitigation>
 		<mitigation level="3"><value resource="backlight">1027</value></mitigation>
-		<mitigation level="3"><value resource="backlight">819</value></mitigation>
+		<mitigation level="4"><value resource="backlight">819</value></mitigation>
 	</control>
 
 	<control name="gpu">
 		<mitigation level="off"><value resource="gpu">450000000</value></mitigation>
+		<mitigation level="1"><value resource="gpu">320000000</value></mitigation>
 		<mitigation level="2"><value resource="gpu">200000000</value></mitigation>
 		<mitigation level="3"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<control name="cpu">
-		<mitigation level="off"><value resource="cpu">2150400</value></mitigation>
-		<mitigation level="1"><value resource="cpu">1958400</value></mitigation>
-		<mitigation level="2"><value resource="cpu">1728000</value></mitigation>
-		<mitigation level="3"><value resource="cpu">1574400</value></mitigation>
-		<mitigation level="4"><value resource="cpu">1497600</value></mitigation>
-		<mitigation level="5"><value resource="cpu">1267200</value></mitigation>
-		<mitigation level="6"><value resource="cpu">1190400</value></mitigation>
-		<mitigation level="7"><value resource="cpu">1036800</value></mitigation>
-		<mitigation level="8"><value resource="cpu">960000</value></mitigation>
-		<mitigation level="9"><value resource="cpu">883200</value></mitigation>
-		<mitigation level="10"><value resource="cpu">729600</value></mitigation>
-		<mitigation level="11"><value resource="cpu">652800</value></mitigation>
-		<mitigation level="12"><value resource="cpu">422400</value></mitigation>
-		<mitigation level="13"><value resource="cpu">300000</value></mitigation>
-		<mitigation level="14"><value resource="shutdown" /></mitigation>
+		<mitigation level="off"><value resource="cpu">1401600</value></mitigation>
+		<mitigation level="1"><value resource="cpu">1344000</value></mitigation>
+		<mitigation level="2"><value resource="cpu">1190400</value></mitigation>
+		<mitigation level="3"><value resource="cpu">1190400</value></mitigation>
+		<mitigation level="4"><value resource="cpu">1094400</value></mitigation>
+		<mitigation level="5"><value resource="cpu">998400</value></mitigation>
+		<mitigation level="6"><value resource="cpu">787200</value></mitigation>
+		<mitigation level="7"><value resource="cpu">600000</value></mitigation>
+		<mitigation level="8"><value resource="cpu">384000</value></mitigation>
+		<mitigation level="9"><value resource="cpu">300000</value></mitigation>
+		<mitigation level="10"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<!-- burn-out protection -->
@@ -150,7 +151,7 @@
 		<threshold>
 			<mitigation name="shutdown" level="off" />
 		</threshold>
-		<threshold trigger="120" clear="115">
+		<threshold trigger="120" clear="100">
 			<mitigation name="shutdown" level="1" />
 		</threshold>
 	</configuration>
@@ -158,31 +159,31 @@
 	<!-- USB and DC -->
 	<configuration sensor="temp-emmc">
 		<threshold>
-			<mitigation name="dc" level="off" />
+			<!--<mitigation name="dc" level="off" />-->
 			<mitigation name="usb" level="off" />
 		</threshold>
-		<threshold trigger="384" clear="364">
-			<mitigation name="dc" level="1" />
+		<threshold trigger="38400" clear="36400">
+			<!--<mitigation name="dc" level="1" />-->
 			<mitigation name="usb" level="1" />
 		</threshold>
-		<threshold trigger="400" clear="380">
-			<mitigation name="dc" level="2" />
+		<threshold trigger="40000" clear="38000">
+			<!--<mitigation name="dc" level="2" />-->
 			<mitigation name="usb" level="2" />
 		</threshold>
-		<threshold trigger="416" clear="396">
-			<mitigation name="dc" level="3" />
+		<threshold trigger="41600" clear="39600">
+			<!--<mitigation name="dc" level="3" />-->
 			<mitigation name="usb" level="3" />
 		</threshold>
-		<threshold trigger="424" clear="412">
-			<mitigation name="dc" level="4" />
+		<threshold trigger="42400" clear="41200">
+			<!--<mitigation name="dc" level="4" />-->
 			<mitigation name="usb" level="4" />
 		</threshold>
-		<threshold trigger="432" clear="420">
-			<mitigation name="dc" level="5" />
+		<threshold trigger="43200" clear="42000">
+			<!--<mitigation name="dc" level="5" />-->
 			<mitigation name="usb" level="5" />
 		</threshold>
-		<threshold trigger="448" clear="440">
-			<mitigation name="dc" level="6" />
+		<threshold trigger="44800" clear="44000">
+			<!--<mitigation name="dc" level="6" />-->
 			<mitigation name="usb" level="6" />
 		</threshold>
 	</configuration>
@@ -192,19 +193,19 @@
 		<threshold>
 			<mitigation name="charging" level="off" />
 		</threshold>
-		<threshold trigger="384" clear="372">
+		<threshold trigger="38400" clear="37200">
 			<mitigation name="charging" level="2" />
 		</threshold>
-		<threshold trigger="400" clear="380">
+		<threshold trigger="40000" clear="38000">
 			<mitigation name="charging" level="4" />
 		</threshold>
-		<threshold trigger="416" clear="396">
+		<threshold trigger="41600" clear="39600">
 			<mitigation name="charging" level="6" />
 		</threshold>
-		<threshold trigger="432" clear="420">
+		<threshold trigger="43200" clear="42000">
 			<mitigation name="charging" level="7" />
 		</threshold>
-		<threshold trigger="448" clear="436">
+		<threshold trigger="44800" clear="43600">
 			<mitigation name="charging" level="8" />
 		</threshold>
 	</configuration>
@@ -225,8 +226,8 @@
 		<threshold>
 			<mitigation name="gpu" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="452">
-			<mitigation name="gpu" level="1" />
+		<threshold trigger="46400" clear="45200">
+			<mitigation name="gpu" level="2" />
 		</threshold>
 	</configuration>
 	<configuration sensor="temp-gpu">
@@ -246,7 +247,7 @@
 		<threshold>
 			<mitigation name="modem" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="452">
+		<threshold trigger="46400" clear="45200">
 			<mitigation name="modem" level="1" />
 		</threshold>
 	</configuration>
@@ -256,16 +257,16 @@
 		<threshold>
 			<mitigation name="backlight" level="off" />
 		</threshold>
-		<threshold trigger="424" clear="412">
+		<threshold trigger="42400" clear="41200">
 			<mitigation name="backlight" level="1" />
 		</threshold>
-		<threshold trigger="440" clear="428">
+		<threshold trigger="44000" clear="42800">
 			<mitigation name="backlight" level="2" />
 		</threshold>
-		<threshold trigger="456" clear="444">
+		<threshold trigger="45600" clear="44400">
 			<mitigation name="backlight" level="3" />
 		</threshold>
-		<threshold trigger="464" clear="452">
+		<threshold trigger="46400" clear="45200">
 			<mitigation name="backlight" level="4" />
 		</threshold>
 	</configuration>
@@ -275,20 +276,23 @@
 		<threshold>
 			<mitigation name="cpu" level="off" />
 		</threshold>
-		<threshold trigger="80" clear="78">
-			<mitigation name="cpu" level="2" />
+		<threshold trigger="80" clear="70">
+			<mitigation name="cpu" level="3" />
 		</threshold>
-		<threshold trigger="90" clear="85">
-			<mitigation name="cpu" level="4" />
+		<threshold trigger="90" clear="80">
+			<mitigation name="cpu" level="6" />
 		</threshold>
-		<threshold trigger="95" clear="90">
+		<threshold trigger="95" clear="85">
+			<mitigation name="cpu" level="7" />
+		</threshold>
+		<threshold trigger="100" clear="90">
+			<mitigation name="cpu" level="8" />
+		</threshold>
+		<threshold trigger="110" clear="100">
 			<mitigation name="cpu" level="9" />
 		</threshold>
-		<threshold trigger="110" clear="95">
-			<mitigation name="cpu" level="12" />
-		</threshold>
-		<threshold trigger="120" clear="115">
-			<mitigation name="cpu" level="14" />
+		<threshold trigger="120" clear="110">
+			<mitigation name="cpu" level="10" />
 		</threshold>
 	</configuration>
 </thermanager>


### PR DESCRIPTION
Thermanager now does its job without spamming log with errors.
TODO: adjust thermal thresholds as they may be too aggressive

Signed-off-by: Adam Farden adam@farden.cz
