### PR TITLE
Adjust thermanager to account for tianchi's dim backlight

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -115,11 +115,11 @@
 	</control>
 
 	<control name="backlight">
-               <mitigation level="off"><value resource="backlight">255</value></mitigation>
-               <mitigation level="1"><value resource="backlight">192</value></mitigation>
-               <mitigation level="2"><value resource="backlight">128</value></mitigation>
-               <mitigation level="3"><value resource="backlight">64</value></mitigation>
-               <mitigation level="4"><value resource="backlight">51</value></mitigation>
+		<mitigation level="off"><value resource="backlight">255</value></mitigation>
+		<mitigation level="1"><value resource="backlight">223</value></mitigation>
+		<mitigation level="2"><value resource="backlight">191</value></mitigation>
+		<mitigation level="3"><value resource="backlight">159</value></mitigation>
+		<mitigation level="4"><value resource="backlight">143</value></mitigation>
 	</control>
 
 	<control name="gpu">


### PR DESCRIPTION
First Boot often triggers the lowest max brightness
which makes the display unusuable.