### PR TITLE
tianchi: use specific idProduct for usb paths

### DIFF
--- a/aosp_d5303.mk
+++ b/aosp_d5303.mk
@@ -54,5 +54,5 @@ PRODUCT_AAPT_PREBUILT_DPI := hdpi
 PRODUCT_AAPT_PREF_CONFIG := hdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=240
-
+    ro.sf.lcd_density=240 \
+    ro.usb.pid_suffix=1A9


### PR DESCRIPTION
from  19.1.1.A.0.165

Signed-off-by: David Viteri <davidteri91@gmail.com>