### PR TITLE
mixer_paths: minor clean up for Android 5.0+

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -145,6 +145,9 @@
     <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="0" />
     <!-- compress-voip-call End-->
 
+    <!-- echo reference -->
+    <ctl name="AUDIO_REF_EC_UL1 MUX" value="None" />
+
     <!-- fm -->
     <ctl name="SLIMBUS_0_RX Port Mixer INTERNAL_FM_TX" value="0" />
     <ctl name="SLIMBUS_DL_HL Switch" value="0" />
@@ -214,7 +217,6 @@
     <ctl name="ANC Function" value="OFF" />
     <!-- anc headset end-->
     <!-- aanc handset mic -->
-    <ctl name="SLIM_0_RX AANC MUX" value="ZERO" />
     <ctl name="AIF1_CAP Mixer SLIM TX3" value="0" />
     <!-- aanc handset mic end -->
     <!-- quad mic -->
@@ -458,6 +460,10 @@
     <path name="voice-call usb-headphones">
         <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
         <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
+    </path>
+
+    <path name="echo-reference">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_RX" />
     </path>
 
     <path name="voice-call incall-music">
@@ -1128,7 +1134,6 @@
         <ctl name="AIF1_CAP Mixer SLIM TX2" value="1" />
         <ctl name="AIF1_CAP Mixer SLIM TX3" value="1" />
         <ctl name="SLIM_0_TX Channels" value="Three" />
-        <ctl name="SLIM_0_RX AANC MUX" value="SLIMBUS_0_TX" />
         <ctl name="SLIM TX1 MUX" value="DEC1" />
         <ctl name="DEC1 MUX" value="ADC1" />
         <ctl name="ADC1 Volume" value="11" />


### PR DESCRIPTION
* Add echo-reference
* Remove 'not found' paths

Signed-off-by: Adam Farden <adam@farden.cz>