### PR TITLE
tianchi: Update NFC NXP HAL naming

### DIFF
--- a/aosp_d5303.mk
+++ b/aosp_d5303.mk
@@ -42,6 +42,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     keystore.msm8226
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.tianchi
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=tianchi
+
 PRODUCT_NAME := aosp_d5303
 PRODUCT_DEVICE := tianchi
 PRODUCT_MODEL := Xperia T2 Ultra (AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba <humberos@gmail.com>