### PR TITLE
Add definitions for a GSM device

### DIFF
--- a/aosp_d5303.mk
+++ b/aosp_d5303.mk
@@ -17,7 +17,12 @@ TARGET_KERNEL_CONFIG := aosp_yukon_tianchi_defconfig
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/tianchi/device.mk)
 $(call inherit-product, frameworks/native/build/phone-xhdpi-1024-dalvik-heap.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    keyguard.no_require_sim=true \
+    ro.com.android.dataroaming=true
 
 PRODUCT_NAME := aosp_d5303
 PRODUCT_DEVICE := tianchi

--- a/device.mk
+++ b/device.mk
@@ -23,6 +23,10 @@ PRODUCT_COPY_FILES := \
     device/sony/tianchi/rootdir/system/etc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
     device/sony/tianchi/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf
 
+# GSM Permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
+
 # IDC
 PRODUCT_COPY_FILES += \
     device/sony/tianchi/rootdir/system/usr/idc/cyttsp4_mt.idc:system/usr/idc/cyttsp4_mt.idc


### PR DESCRIPTION
In an ideal world everyone would be happy with full_base_telephony.mk
but this file is modified in most custom ROMs, so that using the AOSP
repos elsewhere causes crashes that are difficult to debug. It is not
obvious in the logs why the why OOM crashes are caused by the lack of
this permission.

This change fixes that issue and retains complete compatiblity with
AOSP. In fact it fixes one warning due to apns-conf.xml being defined
twice in full_base_telephone.mk and in common.mk.

Signed-off-by: Adam Farden <adam@farden.cz>