### PR TITLE
NFC: Add back lost symlink

### DIFF
--- a/rootdir/init.tianchi.rc
+++ b/rootdir/init.tianchi.rc
@@ -25,6 +25,7 @@ on fs
 
 on post-fs-data
     # Symlink for compability
+    symlink /dev/pn54x /dev/pn544
     symlink /dev/pn54x /dev/pn547
 
 on boot


### PR DESCRIPTION
HAL is hardwired to look at pn544

Signed-off-by: Adam Farden <adam@farden.cz>