### PR TITLE
tianchi: init: Remove unneeded symlink

### DIFF
--- a/rootdir/init.tianchi.rc
+++ b/rootdir/init.tianchi.rc
@@ -16,9 +16,6 @@ import init.common.rc
 import init.common.usb.rc
 import init.yukon.pwr.rc
 
-on init
-    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
-
 on fs
     mount_all ./fstab.tianchi
     write /sys/kernel/boot_adsp/boot 1


### PR DESCRIPTION
This symlink will be created by bootloader
through cmdline parameter:

androidboot.bootdevice=msm_sdcc.1

Signed-off-by: Humberto Borba <humberos@gmail.com>